### PR TITLE
Editing README.md for win11 dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Requirements---
 
 • Your Operating system (OS) should be `Windows 10 version 1803 (build 17134.0) / higher`
 
-• Your Computer should have [developer mode](https://www.wikihow.com/Enable-Developer-Mode-in-Windows-10) turned on(To access it, head to Settings > Update & Security > For Developers and select “Developer mode”) and restart you computer after enabling
+• Your Computer should have [developer mode](https://www.wikihow.com/Enable-Developer-Mode-in-Windows-10) turned on(To access it, head to Settings > Update & Security > For Developers and select “Developer mode”) and restart you computer after enabling (For Windows 11, Go Settings > System > For Developers)
 
 • You should be signed in with a personal Microsoft account in Microsoft store
 


### PR DESCRIPTION
In Builds of Windows 11 23H2 and later, the Dev Options has moved 

https://i.imgur.com/Zy9fx5L.png

![Screenshot 2024-07-21 165225](https://github.com/user-attachments/assets/036ff6ab-0f85-4fad-ba88-d58b3014a086)
